### PR TITLE
Remove `using namespace std` from the cpp template

### DIFF
--- a/platform/api/controllers/ChallengesController.js
+++ b/platform/api/controllers/ChallengesController.js
@@ -196,9 +196,9 @@ module.exports = {
                                     break;
                                 case 'cpp':
                                     if (typeof input === 'string')
-                                        template += `    string value${i} = argv[${i}];`;
+                                        template += `    std::string value${i} = argv[${i}];`;
                                     if (typeof input === 'number')
-                                        template += `    int value${i} = atoi(argv[${i}]);`;
+                                        template += `    int value${i} = std::atoi(argv[${i}]);`;
                                     break;
                                 case 'cs':
                                     if (typeof input === 'string')

--- a/platform/resources/challenges/templates/template.cpp
+++ b/platform/resources/challenges/templates/template.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <string>
 
-using namespace std;
-
 int main(int argc, char **argv) {
     %%_INSERTVALUES_%%
 


### PR DESCRIPTION
`using namespace std` is a bad practice to teach to beginners because it can create unintended name clashes and it's, in general, not recommended (see [here](https://isocpp.org/wiki/faq/coding-standards#using-namespace-std) and [here](https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice)).

In the context of solving the challenges in EMKC this is no harm for sure, but EMKC has been an invaluable tool for me when I was practicing with new languages so I figured that, _as a learning tool_, it should avoid showing discouraged practices.

`using namespace std` is common practice in competitive coding, as those 5 keystrokes every time you need to type `std::` can make a difference, but I don't think that's what EMKC is about :slightly_smiling_face:

Feel free to reject this btw! I always remove that line when doing challenges on EMKC, because I'm used to typing `std::`, so I thought that instead of pointing this out on the Discord I would just make a PR to possibly fix it! :)