### PR TITLE
Challenge 7: More thorough checks 

### DIFF
--- a/platform/resources/challenges/7_check_permutation/tests.json
+++ b/platform/resources/challenges/7_check_permutation/tests.json
@@ -1,20 +1,28 @@
 [
     {
         "official": false,
-        "name": "Permutation",
+        "name": "Testing permutations",
         "input": [
             ["engineer,gireneen"],
             ["cat,act"],
-            ["14467,42641"],
-            ["qwerty,qeerty"],
             ["e1m2k3c4,e2k3m14c"]
         ],
         "output": [
             "Yes",
             "Yes",
-            "No",
-            "No",
             "Yes"
+        ]
+    },
+    {
+        "official": false,
+        "name": "Testing non-permutations",
+        "input": [
+            ["14467,42641"],
+            ["qwerty,qeerty"]
+        ],
+        "output": [
+            "No",
+            "No"
         ]
     }
 ]


### PR DESCRIPTION
This PR implements more thorough test cases for challenge 7 ([`Medium: Check scrambled string`](https://emkc.org/challenges/choose_language/7)).

## The Problem
Before this PR, the user could print `Yes` or `No` and keep trying until their answer matched the correct answers.

### An Example
For example, before this patch, you could solve this challenge by doing:
```python
print("Yes")
```

## Proposed Fix
The fix is quite simple: separate the `Yes` and `No` tests into two distinct categories to test the code on both possibilities. 

This is not foolproof, as a user could still pass the test, given they printed a random selection between `Yes` and `No`. As mentioned in #75, the real way to fix all of these problems is to run the code on all test cases, and have lots of test cases.