### PR TITLE
Add warning when a user exits with an unsaved solution

### DIFF
--- a/platform/resources/jsx/challenge.jsx
+++ b/platform/resources/jsx/challenge.jsx
@@ -78,10 +78,13 @@ class Challenge extends React.Component {
     }
 
     editor_change(_) {
-        // The editor's contents have changed
-        this.setState({
-            changed: true
-        });
+        // Only change state when necessary
+        if (!this.state.changed) {
+            // The editor's contents have changed
+            this.setState({
+                changed: true
+            });
+        }
     }
 
     before_unload(e) {


### PR DESCRIPTION
This PR adds an alert that asks for confirmation when a user leaves the challenges page (e.g. reloading the page, closing the window, going to another page on emkc) with some **unsaved code**.

## Motivations
I have, in the past, almost gotten a solution work, then accidentally closed the emkc tab with `ctrl-w` or similar. Closing the tab results in losing all of my code. It is frustrating when this happens. Giving an alert would bring an end to this frustration.

## Notes
* After the user's solution gets accepted, the prompt will not appear when they try to close the tab (unless they make further changes)
* The user does not receive the prompt unless they try to leave the page and have **unsaved changes**

## Screenshots
On Firefox:
![image](https://user-images.githubusercontent.com/30177086/86637531-b24a2700-bfa3-11ea-8f9e-0f3de04e1871.png)
On Google Chrome:
![image](https://user-images.githubusercontent.com/30177086/86637569-c5f58d80-bfa3-11ea-9257-af53dfd05433.png)
