### PR TITLE
Submissions re-validation, disallowed languages to back-end

### DIFF
--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -188,9 +188,13 @@ module.exports = {
 
         let test_cases = contest.input.split('\n');
         let expected_results = contest.output.split('\n');
+        let languages = await axios.get(constant.get_piston_url() + '/versions');
+        languages = languages.data.filter(lang => lang.name === language);
+        // To prevent submissions by alias
 
         if (!contest.active || test_cases.length !== expected_results.length ||
-            constant.contests.disallowed_languages.includes(language)) {
+            constant.contests.disallowed_languages.includes(language) ||
+            !languages.length) {
             return res
                 .status(400)
                 .send();

--- a/platform/api/services/constant.js
+++ b/platform/api/services/constant.js
@@ -45,6 +45,13 @@ let constant = {
         }
     },
 
+    contests: {
+        disallowed_languages: [
+            'python2',
+            'awk'
+        ]
+    },
+
     channels: {
         emkc: '483979558249562112',
         python: '483980259239264256', // python

--- a/platform/api/services/contests.js
+++ b/platform/api/services/contests.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+
+module.exports = {
+
+    async check_submission_validity(test_cases, expected_results, solution, language) {
+        const timeout = ms => new Promise(res => set_timeout(res, ms));
+        let counter = 0;
+
+        while (counter < test_cases.length) {
+            await timeout(constant.is_prod() ? 0 : 500);
+
+            let current_test_case = test_cases[counter];
+            let current_expected_result = expected_results[counter];
+
+            let test_result = await axios
+                ({
+                    method: 'post',
+                    url: constant.get_piston_url() + '/execute',
+                    data: {
+                        language,
+                        source: solution,
+                        args: current_test_case.trim().split('|')
+                    }
+                });
+            if (test_result.data.output !== current_expected_result) {
+                return false
+            }
+            ++counter;
+        }
+
+        return true;
+    }
+}

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -21,6 +21,7 @@ module.exports.routes = {
     'GET /contests': 'ContestsController.home',
     'POST /contests/submit': 'ContestsController.submit',
     'GET /contests/:contest_id/*': 'ContestsController.contest',
+    'GET /contests/disallowed_languages': 'ContestsController.disallowed_languages',
 
     'GET /snippets': 'SnippetsController.create',
     'POST /snippets': 'SnippetsController.create',
@@ -39,6 +40,7 @@ module.exports.routes = {
 
     // admin
     'GET /admin': 'admin/DashboardController.dashboard',
+    'POST /admin/submissions/validate/:contest_id': 'admin/ContestsController.validate_submissions',
     'GET /admin/contests': 'admin/ContestsController.view_all',
     'GET /admin/contests/all': 'admin/ContestsController.view_all',
     'GET /admin/contests/create': 'admin/ContestsController.create',


### PR DESCRIPTION
Allow admins to re-validate contest submissions and prevent users from submitting with disallowed languages.
closes #119 