### PR TITLE
Compare the expected output against stdout

### DIFF
--- a/platform/api/services/contests.js
+++ b/platform/api/services/contests.js
@@ -24,7 +24,7 @@ module.exports = {
                     }
                 });
 
-            if (test_result.data.output !== current_expected_result) {
+            if (test_result.data.stdout !== current_expected_result) {
                 return false;
             }
 


### PR DESCRIPTION
This allows compiled languages to trigger warnings, because the compiler output is in the `output` field of piston's answer, but the `stdout` field contains only the output of the actual execution.