### PR TITLE
Support Piston v3

### DIFF
--- a/platform/api/controllers/ChallengesController.js
+++ b/platform/api/controllers/ChallengesController.js
@@ -346,11 +346,14 @@ module.exports = {
             let test_idx = Math.floor(Math.random() * inputs.length);
             let outputs = test.output.split('\n')
 
+            let result = await piston.execute(language, source, inputs[test_idx].split('|'),'','*');
+            result = result.run.stdout.trim();
+
             results.push({
                 name: test.name,
                 input: inputs[test_idx],
                 expected: outputs[test_idx],
-                result: await piston.execute(language, source, inputs[test_idx].split('|'))
+                result
             });
         }
 

--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -192,7 +192,7 @@ module.exports = {
         let languages = await piston.runtimes();
 
         languages = languages
-            .filter(lang => lang.name === language);
+            .filter(lang => lang.language === language);
 
         // To prevent submissions by alias
         if (test_cases.length !== expected_results.length ||

--- a/platform/api/controllers/admin/ContestsController.js
+++ b/platform/api/controllers/admin/ContestsController.js
@@ -144,7 +144,8 @@ module.exports = {
                     contest.input.split('\n'),
                     contest.output.split('\n'),
                     submission.solution,
-                    submission.language
+                    submission.language,
+                    submission.language_version,
                 );
 
             if (!is_valid) {

--- a/platform/api/controllers/admin/PistonController.js
+++ b/platform/api/controllers/admin/PistonController.js
@@ -1,0 +1,36 @@
+module.exports = {
+
+    async view_all(req, res) {
+        return res.view({
+            message: null
+        });
+    },
+
+    async packages(req, res){
+        let packages = await piston.packages();
+        return res
+            .status(200)
+            .send(packages);
+    },
+    
+    async install(req, res){
+        let {language,version} = req.query;
+
+        let result = await piston.install(language, version);
+
+        return res.view('admin/piston/view_all',{
+            message: `Installation of ${language}-${version} ${result.language ? "succeeded" : "failed: " + result.message}`
+        });
+        
+    },
+    async uninstall(req, res){
+        let {language,version} = req.query;
+
+        let result = await piston.uninstall(language, version);
+
+        return res.view('admin/piston/view_all', {
+            message: `Uninstallation of ${language}-${version} ${result.language ? "succeeded" : "failed: " + result.message}`
+        });
+        
+    },
+}

--- a/platform/api/controllers/api/v2/PistonController.js
+++ b/platform/api/controllers/api/v2/PistonController.js
@@ -87,7 +87,7 @@ module.exports = {
                 return res
                     .status(500)
                     .send({
-                        message: 'Execution problem'
+                        message: 'Execution problem: ' + e.message
                     });
             }
         }

--- a/platform/api/controllers/api/v2/PistonController.js
+++ b/platform/api/controllers/api/v2/PistonController.js
@@ -3,7 +3,7 @@ const Redis = require('ioredis');
 
 module.exports = {
 
-    async versions(req, res) {
+    async runtimes(req, res) {
         res.set('Access-Control-Allow-Origin', '*');
         res.set('Access-Control-Allow-Headers', '*');
 
@@ -16,11 +16,6 @@ module.exports = {
 
         let result = await piston.runtimes();
 
-        result = result.map(lang => ({
-            name: lang.language,
-            version: lang.version,
-            aliases: lang.aliases
-        }));
 
         return res
             .status(200)
@@ -59,14 +54,14 @@ module.exports = {
 
         redis.disconnect();
 
-        let { language, source, args, stdin, version } = req.body;
+        let { language, files, args, stdin, version } = req.body;
 
         try {
             let result = await piston.execute(language,
-                source,
+                files,
                 args,
                 stdin,
-                version || '*', //default to latest version
+                version,
                 {
                     server: 'Piston API',
                     user: 'Direct Usage'
@@ -75,24 +70,10 @@ module.exports = {
             return res
                 .status(200)
                 .send({
-                    ran: result.ran,
                     language: result.language,
                     version: result.version,
-                    output: result.output
-                        ? result.output
-                            .replace(/\r/gi, '')
-                            .slice(0, 65536)
-                        : '',
-                    stdout: result.stdout
-                        ? result.stdout
-                            .replace(/\r/gi, '')
-                            .slice(0, 65536)
-                        : '',
-                    stderr: result.stderr
-                        ? result.stderr
-                            .replace(/\r/gi, '')
-                            .slice(0, 65536)
-                        : ''
+                    run: result.run,
+                    compile: result.compile
                 });
 
         }catch(e){

--- a/platform/api/services/contests.js
+++ b/platform/api/services/contests.js
@@ -4,7 +4,7 @@ const timeout = ms => new Promise(res => set_timeout(res, ms));
 
 module.exports = {
 
-    async check_submission_validity(test_cases, expected_results, solution, language) {
+    async check_submission_validity(test_cases, expected_results, solution, language, version) {
         let counter = 0;
 
         while (counter < test_cases.length) {
@@ -15,19 +15,17 @@ module.exports = {
 
             let args = current_test_case.trim().split('|');
 
-            let test_result = await axios
-                ({
-                    method: 'post',
-                    url: constant.get_piston_url() + '/execute',
-                    data: {
-                        language,
-                        source: solution,
-                        args,
-                        stdin: args.join('\n'),
-                    }
-                });
+            let test_result = await piston.execute(
+                language,
+                solution,
+                args,
+                args.join('\n'),
+                version
+            );
 
-            if (test_result.data.stdout !== current_expected_result) {
+
+
+            if (test_result.run.stdout.trim() !== current_expected_result) {
                 return false;
             }
 

--- a/platform/api/services/piston.js
+++ b/platform/api/services/piston.js
@@ -35,10 +35,7 @@ module.exports = {
             url: constant.get_piston_url() + '/api/v1/runtimes'
         });
 
-        return result.data.map(rt => ({
-            ...rt,
-            name: rt.language
-        }));
+        return result.data;
     },
 
     async packages(){
@@ -56,9 +53,14 @@ module.exports = {
         return result.data
     },
 
-    async execute(language, source, args, stdin, version, log_message = emkc_internal_log_message){
+    async execute(language, files, args, stdin, version, log_message = emkc_internal_log_message){
         if (!Array.is_array(args)) {
             args = [];
+        }
+
+        if(typeof files === 'string'){
+            //Assume this is just source, not files
+            files=[{content: files}];
         }
 
         await timeout(constant.is_prod() ? 0 : 500);  // Delay by 0.5 seconds when using the public api
@@ -69,8 +71,8 @@ module.exports = {
                 url: constant.get_piston_url() + '/api/v1/execute',
                 data: {
                     language,
-                    version: version,
-                    files: [{content: source}],
+                    version,
+                    files,
                     args,
                     stdin,
                     compile_timeout: sails.config.piston.timeouts.compile,

--- a/platform/api/services/piston.js
+++ b/platform/api/services/piston.js
@@ -1,6 +1,17 @@
-const request = require('request-promise');
-
+const axios = require('axios');
 const timeout = ms => new Promise(res => set_timeout(res, ms));
+
+const emkc_internal_log_message = {
+    server: 'EMKC',
+    user: 'EMKC Usage'
+};
+
+class PistonError extends Error {
+    constructor(message, status_code){
+        super(message);
+        this.status_code = status_code;
+    }
+}
 
 module.exports = {
 
@@ -17,46 +28,90 @@ module.exports = {
         java: 'java'
     },
 
-    async execute(language, source, args) {
+    async runtimes(){
+        let result = await axios
+        ({
+            method: 'get',
+            url: constant.get_piston_url() + '/api/v1/runtimes'
+        });
+
+        return result.data.map(rt => ({
+            ...rt,
+            name: rt.language
+        }));
+    },
+
+    async packages(){
+        let result = await axios.get(constant.get_piston_url() + '/api/v1/packages');
+        return result.data;
+    },
+
+    async install(language, version){
+        let result = await axios.post(constant.get_piston_url() + `/api/v1/packages/${language}/${version}`)
+        return result.data
+    },
+
+    async uninstall(language, version){
+        let result = await axios.delete(constant.get_piston_url() + `/api/v1/packages/${language}/${version}`)
+        return result.data
+    },
+
+    async execute(language, source, args, stdin, version, log_message = emkc_internal_log_message){
         if (!Array.is_array(args)) {
-            args = [args];
+            args = [];
         }
 
-        args = args.map(arg => '' + arg);
+        await timeout(constant.is_prod() ? 0 : 500);  // Delay by 0.5 seconds when using the public api
 
-        try {
-            await timeout(constant.is_prod() ? 0 : 500);  // Delay by 0.5 seconds when using the public api
-
-            let result = await request
-                ({
-                    method: 'post',
-                    url: constant.is_prod()
-                        ? 'http://' + sails.config.piston.host + '/execute'
-                        : 'https://emkc.org/api/v1/piston/execute',
-                    body: {
-                        language,
-                        source,
-                        args
-                    },
-                    json: true,
-                    simple: true
-                });
-
-            // send to piston logs for stats
-            db.piston_runs
-                .create({
-                    server: 'EMKC',
-                    user: 'EMKC Usage',
+        let result = await axios
+            ({
+                method: 'post',
+                url: constant.get_piston_url() + '/api/v1/execute',
+                data: {
                     language,
-                    source
-                });
+                    version: version,
+                    files: [{content: source}],
+                    args,
+                    stdin,
+                    compile_timeout: sails.config.piston.timeouts.compile,
+                    run_timeout: sails.config.piston.timeouts.run,
+                }
+            });
 
-            return typeof result.output === 'string'
-                ? result.output.slice(0, 1024)
-                : '';
-        } catch(e) {
-            return '';
+        if(result.status !== 200)
+            throw new PistonError(result.data.message, result.status)
+        
+        db.piston_runs.create({...log_message, language, source});
+
+        let output = "";
+        let stdout = "";
+        let stderr = "";
+        let ran = true;
+
+        if(result.data.compile){
+            output += result.data.compile.output;
+            stdout += result.data.compile.stdout;
+            stderr += result.data.compile.stderr;
+            ran = ran && (result.data.compile.code == 0);
         }
+
+        if(result.data.run){
+            output += result.data.run.output;
+            stdout += result.data.run.stdout;
+            stderr += result.data.run.stderr;
+            ran = ran && (result.data.run.code == 0);
+        }
+
+        return {
+            ...result.data,
+            output,
+            stdout,
+            stderr,
+            ran
+        };
+
+            
+
     }
 
 };

--- a/platform/api/services/piston.js
+++ b/platform/api/services/piston.js
@@ -8,7 +8,9 @@ const emkc_internal_log_message = {
 
 class PistonError extends Error {
     constructor(message, status_code){
-        super(message);
+        super(status_code + ": " + message);
+        this.message = message;
+        this.error_message = message;
         this.status_code = status_code;
     }
 }
@@ -83,7 +85,7 @@ module.exports = {
         if(result.status !== 200)
             throw new PistonError(result.data.message, result.status)
         
-        db.piston_runs.create({...log_message, language, source});
+        db.piston_runs.create({...log_message, language, source: files[0].content});
 
         let output = "";
         let stdout = "";

--- a/platform/config/local.js.sample
+++ b/platform/config/local.js.sample
@@ -45,6 +45,10 @@ module.exports = {
     },
     piston: {
         host: '127.0.0.1:2000',
+        timeouts: {
+            run: 3000,
+            compile: 10000
+        },
         key: ''
     },
     dispenserd: {

--- a/platform/config/policies.js
+++ b/platform/config/policies.js
@@ -65,6 +65,10 @@ module.exports.policies = {
         '*': ['common', 'logged_in', 'is_admin']
     },
 
+    'admin/PistonController': {
+        '*': ['common', 'logged_in', 'is_admin']
+    },
+
     'api/internal/ChatsController': {
         '*': ['common', 'api_internal_auth']
     },

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -79,6 +79,9 @@ module.exports.routes = {
     'OPTIONS /api/v1/piston/versions': 'api/v1/PistonController.versions',
     'POST /api/v1/piston/execute': 'api/v1/PistonController.execute',
     'OPTIONS /api/v1/piston/execute': 'api/v1/PistonController.execute',
+    'OPTIONS /api/v2/piston/runtimes': 'api/v2/PistonController.runtimes',
+    'POST /api/v2/piston/execute': 'api/v2/PistonController.execute',
+    'OPTIONS /api/v2/piston/execute': 'api/v2/PistonController.execute',
 
     // catch all (404)
     'ALL r|^\/(?!cdn|css|images|js|lib|other|robots\.txt|google*)|': 'HomeController.fourohfour',

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -79,6 +79,7 @@ module.exports.routes = {
     'OPTIONS /api/v1/piston/versions': 'api/v1/PistonController.versions',
     'POST /api/v1/piston/execute': 'api/v1/PistonController.execute',
     'OPTIONS /api/v1/piston/execute': 'api/v1/PistonController.execute',
+    'GET /api/v2/piston/versions': 'api/v2/PistonController.versions',
     'OPTIONS /api/v2/piston/runtimes': 'api/v2/PistonController.runtimes',
     'POST /api/v2/piston/execute': 'api/v2/PistonController.execute',
     'OPTIONS /api/v2/piston/execute': 'api/v2/PistonController.execute',

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -79,7 +79,7 @@ module.exports.routes = {
     'OPTIONS /api/v1/piston/versions': 'api/v1/PistonController.versions',
     'POST /api/v1/piston/execute': 'api/v1/PistonController.execute',
     'OPTIONS /api/v1/piston/execute': 'api/v1/PistonController.execute',
-    'GET /api/v2/piston/versions': 'api/v2/PistonController.versions',
+    'GET /api/v2/piston/runtimes': 'api/v2/PistonController.versions',
     'OPTIONS /api/v2/piston/runtimes': 'api/v2/PistonController.runtimes',
     'POST /api/v2/piston/execute': 'api/v2/PistonController.execute',
     'OPTIONS /api/v2/piston/execute': 'api/v2/PistonController.execute',

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -79,7 +79,7 @@ module.exports.routes = {
     'OPTIONS /api/v1/piston/versions': 'api/v1/PistonController.versions',
     'POST /api/v1/piston/execute': 'api/v1/PistonController.execute',
     'OPTIONS /api/v1/piston/execute': 'api/v1/PistonController.execute',
-    'GET /api/v2/piston/runtimes': 'api/v2/PistonController.versions',
+    'GET /api/v2/piston/runtimes': 'api/v2/PistonController.runtimes',
     'OPTIONS /api/v2/piston/runtimes': 'api/v2/PistonController.runtimes',
     'POST /api/v2/piston/execute': 'api/v2/PistonController.execute',
     'OPTIONS /api/v2/piston/execute': 'api/v2/PistonController.execute',

--- a/platform/config/routes.js
+++ b/platform/config/routes.js
@@ -59,6 +59,10 @@ module.exports.routes = {
     'POST /admin/submissions/delete': 'admin/ContestsController.delete_submission',
     'GET /admin/users': 'admin/UsersController.view_all',
     'GET /admin/users/login_as': 'admin/UsersController.login_as',
+    'GET /admin/piston': 'admin/PistonController.view_all',
+    'GET /admin/piston/packages': 'admin/PistonController.packages',
+    'GET /admin/piston/install': 'admin/PistonController.install',
+    'GET /admin/piston/uninstall': 'admin/PistonController.uninstall',
 
     // service api
     'GET /api/internal/chats/last': 'api/internal/ChatsController.last',

--- a/platform/migrations/migrations/20210423100104-add-language-version.sql
+++ b/platform/migrations/migrations/20210423100104-add-language-version.sql
@@ -1,0 +1,5 @@
+up:
+alter table contest_submissions add language_version varchar(32) not null after length;
+
+down:
+alter table contest_submissions drop column language_version;

--- a/platform/models/contest_submissions.js
+++ b/platform/models/contest_submissions.js
@@ -13,6 +13,7 @@ module.exports = (sequelize, DataTypes) => {
             user_id: DataTypes.INTEGER,
             contest_id: DataTypes.INTEGER,
             language: DataTypes.STRING,
+            language_version: DataTypes.STRING,
             solution: DataTypes.TEXT('medium'),
             length: DataTypes.INTEGER,
             explanation: DataTypes.TEXT('medium'),

--- a/platform/resources/jsx/contests/contest.jsx
+++ b/platform/resources/jsx/contests/contest.jsx
@@ -126,6 +126,7 @@ class Contest extends React.Component {
                 showing_late,
                 shown_submissions,
                 language: submission ? submission.language : prev.language,
+                language_version: submission ? submission.language_version : prev.language_version,
                 solution: submission ? submission.solution : '',
                 explanation: submission ? submission.explanation : '',
             };

--- a/platform/resources/jsx/contests/contest.jsx
+++ b/platform/resources/jsx/contests/contest.jsx
@@ -14,6 +14,7 @@ class Contest extends React.Component {
         this.state = {
             contest: props.contest,
             language: '',
+            language_version: '',
             solution: '',
             explanation: '',
             languages: [],
@@ -34,6 +35,7 @@ class Contest extends React.Component {
 
         if (submission) {
             this.state.language = submission.language;
+            this.state.language_version = submission.language_version;
             this.state.solution = submission.solution;
             this.state.explanation = submission.explanation;
         }
@@ -65,6 +67,7 @@ class Contest extends React.Component {
         this.setState({
             languages,
             language: this.state.language || languages[0].name,
+            language_version: this.state.language_version || languages[0].version,
             shown_submissions: this.on_time_submissions
         });
     }
@@ -74,20 +77,26 @@ class Contest extends React.Component {
         let value = e.target.value;
 
         if (id === 'language') {
+            
+
+            let [language, language_version] = value.split('-');
+
             let submission = this.props.submissions
                 .find(submission => {
-                    return submission.language === value && !!submission.late === !this.state.contest.active
+                    return submission.language === language && submission.language_version === language_version && !!submission.late === !this.state.contest.active
                 });
 
             this.setState({
                 solution: submission ? submission.solution : '',
                 explanation: submission ? submission.explanation : '',
+                language, language_version
+            });
+        }else{
+
+            this.setState({
+                [id]: value
             });
         }
-
-        this.setState({
-            [id]: value
-        });
     }
 
     toggle_explanation = submission => {
@@ -128,7 +137,7 @@ class Contest extends React.Component {
             passed: true
         });
 
-        const { language, solution, explanation } = this.state;
+        const { language, solution, explanation, language_version } = this.state;
 
         this.setState({
             submitting: true
@@ -139,7 +148,8 @@ class Contest extends React.Component {
                 contest_id: this.state.contest.contest_id,
                 language,
                 solution,
-                explanation
+                explanation,
+                language_version
             });
 
         this.setState({
@@ -268,13 +278,13 @@ class Contest extends React.Component {
                                             id="language"
                                             class="form-control"
                                             style={{ width: '200px'}}
-                                            value={this.state.language}
+                                            value={this.state.language + "-" + this.state.language_version}
                                             onChange={this.handle_change}>
                                             {this.state.languages.map(language => {
                                                 return (
                                                     <option
-                                                        key={language.name}
-                                                        value={language.name}>{language.name} ({language.version})</option>
+                                                        key={language.name + "-" + language.version}
+                                                        value={language.name + "-" + language.version}>{language.name} ({language.version})</option>
                                                 )
                                             })}
                                         </select>

--- a/platform/resources/jsx/ppman.jsx
+++ b/platform/resources/jsx/ppman.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import axios from 'axios';
+
+import Util from 'js/util';
+
+class PistonPackageManager extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            packages: [],
+            message: props.message
+        };
+    }
+
+    async componentDidMount() {
+        let packages = await axios.get('/admin/piston/packages');
+        packages = packages.data;
+        console.log(packages);
+
+        this.setState({packages});
+    }
+
+
+    render() {
+        return (
+            <div>
+                <h1>{this.state.message}</h1>
+                <table class="table table-sm table-dark">
+                    <tr>
+                        <th style={{ width: '100px' }}></th>
+                        <th>Name</th>
+                        <th>Version</th>
+                        <th>Installed</th>
+                    </tr>
+                    {this.state.packages.map(pkg => {
+                        return (
+                            <tr>
+                                <td>
+                                    {pkg.installed ? 
+                                        <a
+                                            key={pkg.language + '-' + pkg.language_version}
+                                            href={`/admin/piston/uninstall?language=${pkg.language}&version=${pkg.language_version}`}
+                                            class="user_row marginbottom20">
+                                            Uninstall
+                                        </a>
+                                        :
+                                        <a
+                                            key={pkg.language + '-' + pkg.language_version}
+                                            href={`/admin/piston/install?language=${pkg.language}&version=${pkg.language_version}`}
+                                            class="user_row marginbottom20">
+                                            Install
+                                        </a>
+                                    }
+                                </td>
+                                <td>{pkg.language}</td>
+                                <td>{pkg.language_version}</td>
+                                <td>{pkg.installed ? "Yes": "No"}</td>
+                            </tr>
+                        );
+                    })}
+                </table>
+            </div>
+        );
+    }
+
+}
+
+Util.try_render('react_ppman', PistonPackageManager);
+
+export default PistonPackageManager;

--- a/platform/views/admin/piston/view_all.twig
+++ b/platform/views/admin/piston/view_all.twig
@@ -1,0 +1,8 @@
+{% extends 'master.twig'%}
+{% block title %}Piston | EMKC{% endblock %}
+{% block content %}
+    <div
+        id="react_ppman"
+        data-message="{{ message|json_encode|e }}"
+    ></div>
+{% endblock %}

--- a/platform/views/master.twig
+++ b/platform/views/master.twig
@@ -116,7 +116,8 @@
                     Staff Stuff:
                     <a href="/admin/users">Users</a> |
                     <a href="/admin/contests">Contests</a> |
-                    <a href="/admin/challenges">Challenges</a>
+                    <a href="/admin/challenges">Challenges</a> |
+                    <a href="/admin/piston">Piston</a>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
* Adds a new page for staff to install/uninstall packages
* Allows contests to be submitted in multiple versions
* Piston service exposes all piston related methods
* Removed any direct calls to piston and replaced with calls through piston service

Configuration should have new keys added to it.
See sample & diff for info.
Will also require applying the new migration.