### PR TITLE
Allow 1 solution per language

### DIFF
--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -222,7 +222,6 @@ module.exports = {
                 where: {
                     contest_id,
                     language,
-                    language_version,
                     user_id: req.local.user_id,
                     late: contest.active ? 0 : 1
                 }

--- a/platform/api/controllers/admin/ContestsController.js
+++ b/platform/api/controllers/admin/ContestsController.js
@@ -145,7 +145,7 @@ module.exports = {
                     contest.output.split('\n'),
                     submission.solution,
                     submission.language,
-                    submission.language_version,
+                    submission.language_version || '*', // Default to latest, just incase its blank
                 );
 
             if (!is_valid) {

--- a/platform/api/controllers/api/v2/PistonController.js
+++ b/platform/api/controllers/api/v2/PistonController.js
@@ -54,7 +54,7 @@ module.exports = {
 
         redis.disconnect();
 
-        let { language, files, args, stdin, version } = req.body;
+        let { language, files, args, stdin, version, run_timeout, compile_timeout } = req.body;
 
         try {
             let result = await piston.execute(language,
@@ -65,6 +65,9 @@ module.exports = {
                 {
                     server: 'Piston API',
                     user: 'Direct Usage'
+                },{
+                    run: run_timeout,
+                    compile: compile_timeout
                 });
 
             return res

--- a/platform/api/services/piston.js
+++ b/platform/api/services/piston.js
@@ -55,7 +55,7 @@ module.exports = {
         return result.data
     },
 
-    async execute(language, files, args, stdin, version, log_message = emkc_internal_log_message){
+    async execute(language, files, args, stdin, version, log_message = emkc_internal_log_message, timeouts={}){
         if (!Array.is_array(args)) {
             args = [];
         }
@@ -67,6 +67,15 @@ module.exports = {
 
         await timeout(constant.is_prod() ? 0 : 500);  // Delay by 0.5 seconds when using the public api
 
+        let compile_timeout = sails.config.piston.timeouts.compile;
+        let run_timeout = sails.config.piston.timeouts.run;
+        
+        if(timeouts.compile < compile_timeout )
+            compile_timeout = timeouts.compile;
+            
+        if(timeouts.run < run_timeout )
+            run_timeout = timeouts.run;
+
         let result = await axios
             ({
                 method: 'post',
@@ -77,8 +86,8 @@ module.exports = {
                     files,
                     args,
                     stdin,
-                    compile_timeout: sails.config.piston.timeouts.compile,
-                    run_timeout: sails.config.piston.timeouts.run,
+                    compile_timeout: compile_timeout,
+                    run_timeout: run_timeout,
                 }
             });
 


### PR DESCRIPTION
Currently, we allow 1 solution per language per version. This implements a fix to cut that down to 1 solution per language.

Also adds additional parameters to piston api, allowing the user to set timeouts, up to the maximum value.