### PR TITLE
Set draft contests as inactive

### DIFF
--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -1,6 +1,3 @@
-const moment = require('moment');
-const axios = require('axios');
-
 module.exports = {
 
     async home(req, res) {
@@ -214,6 +211,16 @@ module.exports = {
                 .status(200)
                 .send({
                     passed: false
+                });
+        }
+
+        if (!!contest.draft)
+        {
+            // Don't save solution for draft contests
+            return res
+                .status(200)
+                .send({
+                    passed: true
                 });
         }
 

--- a/platform/models/contests.js
+++ b/platform/models/contests.js
@@ -25,7 +25,9 @@ module.exports = (sequelize, DataTypes) => {
             active: {
                 type: DataTypes.VIRTUAL,
                 get() {
-                    return moment().isAfter(moment(this.start_date)) && moment().isBefore(moment(this.end_date));
+                    return moment().isAfter(moment(this.start_date))
+                        && moment().isBefore(moment(this.end_date))
+                        && !this.draft;
                 }
             },
             url: {


### PR DESCRIPTION
Prevents Felix from announcing draft contests solutions when the contests are drafted but they have the same date as the current date. Doesn't save such solutions.