### PR TITLE
Allow hiding of contest arguments and output on a case-by-case basis

### DIFF
--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -1,55 +1,5 @@
 const moment = require("moment");
 
-function get_cases(contest, redact=false){
-    let inputs = contest.input.split('\n').map(input => input.split("|"));
-    let outputs = contest.output.split('\n');
-
-    let cases = [];
-
-    for (let i = 0; i < inputs.length; ++i) {
-        let input = inputs[i]
-        
-        let this_case = {
-            hide_input: false,
-            hide_output: false,
-            hide_ignore_active: false,
-            args: input,
-            stdin: input.join("\n"),
-            output: outputs[i].replace(/\\n/g, '\n')
-        }
-
-        if(input[0].length == 0){ // starts with a pipe
-            //|opt_string|.....
-            this_case.args = input.splice(2)
-            this_case.stdin = this_case.args.join("\n")
-            
-            let opt_string = input[1]
-            
-            // e.g. |hide_input,hide_output|hello|world
-            opt_string.split(",").for_each(opt => {
-                let vals = opt.split("=")
-                this_case[vals[0]] = vals.length == 1 || vals[1] // true if there is no =, else the value after the =
-            })
-            
-        }
-
-        // Hide data from the front-end, but not from the backend
-        if(redact && (contest.active || this_case.hide_ignore_active )){
-            if(this_case.hide_input){
-                this_case.args = this_case.args.map(_=>"hidden");
-                this_case.stdin = "[hidden]"
-            }
-            if(this_case.hide_output){
-                this_case.output = "[hidden]";
-            }
-        }
-
-        cases.push(this_case);
-    }
-
-    return cases
-}
-
 module.exports = {
 
     async home(req, res) {
@@ -185,7 +135,7 @@ module.exports = {
         let awarded_users = [];
         let top = 1;
 
-        let cases = get_cases(contest, true)
+        let cases = contests.get_cases(contest, true)
 
         contest.submissions
             .for_each((submission, i) => {
@@ -249,7 +199,7 @@ module.exports = {
                 }
             });
         
-        let test_cases = get_cases(contest)
+        let test_cases = contests.get_cases(contest)
         let languages = await piston.runtimes();
 
         languages = languages

--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -249,7 +249,7 @@ module.exports = {
                 }
             });
         
-        let test_cases = get_case(contest)
+        let test_cases = get_cases(contest)
         let languages = await piston.runtimes();
 
         languages = languages

--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -1,5 +1,55 @@
 const moment = require("moment");
 
+function get_cases(contest, redact=false){
+    let inputs = contest.input.split('\n').map(input => input.split("|"));
+    let outputs = contest.output.split('\n');
+
+    let cases = [];
+
+    for (let i = 0; i < inputs.length; ++i) {
+        let input = inputs[i]
+        
+        let this_case = {
+            hide_input: false,
+            hide_output: false,
+            hide_ignore_active: false,
+            args: input,
+            stdin: input.join("\n"),
+            output: outputs[i].replace(/\\n/g, '\n')
+        }
+
+        if(input[0].length == 0){ // starts with a pipe
+            //|opt_string|.....
+            this_case.args = input.splice(2)
+            this_case.stdin = this_case.args.join("\n")
+            
+            let opt_string = input[1]
+            
+            // e.g. |hide_input,hide_output|hello|world
+            opt_string.split(",").for_each(opt => {
+                let vals = opt.split("=")
+                this_case[vals[0]] = vals.length == 1 || vals[1] // true if there is no =, else the value after the =
+            })
+            
+        }
+
+        // Hide data from the front-end, but not from the backend
+        if(redact && (contest.active || this_case.hide_ignore_active )){
+            if(this_case.hide_input){
+                this_case.args = this_case.args.map(_=>"hidden");
+                this_case.stdin = "[hidden]"
+            }
+            if(this_case.hide_output){
+                this_case.output = "[hidden]";
+            }
+        }
+
+        cases.push(this_case);
+    }
+
+    return cases
+}
+
 module.exports = {
 
     async home(req, res) {
@@ -135,17 +185,7 @@ module.exports = {
         let awarded_users = [];
         let top = 1;
 
-        let inputs = contest.input.split('\n').map(o => o.split('|'));
-        let outputs = contest.output.split('\n');
-
-        let cases = [];
-
-        for (let i = 0; i < inputs.length; ++i) {
-            cases.push({
-                inputs: inputs[i],
-                output: outputs[i]
-            });
-        }
+        let cases = get_cases(contest, true)
 
         contest.submissions
             .for_each((submission, i) => {
@@ -208,17 +248,15 @@ module.exports = {
                     contest_id
                 }
             });
-
-        let test_cases = contest.input.split('\n');
-        let expected_results = contest.output.split('\n');
+        
+        let test_cases = get_case(contest)
         let languages = await piston.runtimes();
 
         languages = languages
             .filter(lang => lang.language === language);
 
         // To prevent submissions by alias
-        if (test_cases.length !== expected_results.length ||
-            constant.contests.disallowed_languages.includes(language) ||
+        if (constant.contests.disallowed_languages.includes(language) ||
             !languages.length) {
 
             return res
@@ -229,7 +267,7 @@ module.exports = {
         }
 
         let is_valid = await contests
-            .check_submission_validity(test_cases, expected_results, solution, language, language_version);
+            .check_submission_validity(test_cases, solution, language, language_version);
 
         if (!is_valid) {
             return res

--- a/platform/api/controllers/admin/ContestsController.js
+++ b/platform/api/controllers/admin/ContestsController.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 module.exports = {
 
     async view_all(req, res) {
-        let contests = await db.contests
+        let all_contests = await db.contests
             .find_all({
                 order: [
                     ['contest_id', 'desc']
@@ -11,7 +11,7 @@ module.exports = {
             });
 
         return res.view({
-            contests
+            contests: all_contests
         });
     },
 
@@ -132,7 +132,7 @@ module.exports = {
             ]
         });
 
-        let test_cases = get_cases(contest)
+        let test_cases = contests.get_cases(contest)
 
         let invalids = [];
 

--- a/platform/api/controllers/admin/ContestsController.js
+++ b/platform/api/controllers/admin/ContestsController.js
@@ -132,13 +132,14 @@ module.exports = {
             ]
         });
 
+        let test_cases = get_cases(contest)
+
         let invalids = [];
 
         for (let submission of contest.submissions) {
             let is_valid = await contests
                 .check_submission_validity(
-                    contest.input.split('\n'),
-                    contest.output.split('\n'),
+                    test_cases,
                     submission.solution,
                     submission.language,
                     submission.language_version || '*', // Default to latest, just incase its blank

--- a/platform/api/services/contests.js
+++ b/platform/api/services/contests.js
@@ -1,6 +1,55 @@
 const timeout = (ms) => new Promise((res) => set_timeout(res, ms));
 
 module.exports = {
+    get_cases(contest, redact=false){
+        let inputs = contest.input.split('\n').map(input => input.split("|"));
+        let outputs = contest.output.split('\n');
+    
+        let cases = [];
+    
+        for (let i = 0; i < inputs.length; ++i) {
+            let input = inputs[i]
+            
+            let this_case = {
+                hide_input: false,
+                hide_output: false,
+                hide_ignore_active: false,
+                args: input,
+                stdin: input.join("\n"),
+                output: outputs[i].replace(/\\n/g, '\n')
+            }
+    
+            if(input[0].length == 0){ // starts with a pipe
+                //|opt_string|.....
+                this_case.args = input.splice(2)
+                this_case.stdin = this_case.args.join("\n")
+                
+                let opt_string = input[1]
+                
+                // e.g. |hide_input,hide_output|hello|world
+                opt_string.split(",").for_each(opt => {
+                    let vals = opt.split("=")
+                    this_case[vals[0]] = vals.length == 1 || vals[1] // true if there is no =, else the value after the =
+                })
+                
+            }
+    
+            // Hide data from the front-end, but not from the backend
+            if(redact && (contest.active || this_case.hide_ignore_active )){
+                if(this_case.hide_input){
+                    this_case.args = this_case.args.map(_=>"hidden");
+                    this_case.stdin = "[hidden]"
+                }
+                if(this_case.hide_output){
+                    this_case.output = "[hidden]";
+                }
+            }
+    
+            cases.push(this_case);
+        }
+    
+        return cases
+    },    
     async check_submission_validity(test_cases, solution, language, version) {
         let counter = 0;
 

--- a/platform/api/services/contests.js
+++ b/platform/api/services/contests.js
@@ -1,27 +1,24 @@
 const timeout = (ms) => new Promise((res) => set_timeout(res, ms));
 
 module.exports = {
-    async check_submission_validity(test_cases, expected_results, solution, language, version) {
+    async check_submission_validity(test_cases, solution, language, version) {
         let counter = 0;
 
         while (counter < test_cases.length) {
             await timeout(constant.is_prod() ? 0 : 500);
 
             let current_test_case = test_cases[counter];
-            let current_expected_result = expected_results[counter];
-
-            let args = current_test_case.trim().split('|');
-
+            
             try {
                 let test_result = await piston.execute(
                     language,
                     solution,
-                    args,
-                    args.join('\n'),
+                    current_test_case.args,
+                    current_test_case.stdin,
                     version
                 );
                 if (
-                    test_result.run.stdout.trim() !== current_expected_result.replace(/\\n/g, '\n')
+                    test_result.run.stdout.trim() !== current_test_case.output.trim()
                 ) {
                     return false;
                 }

--- a/platform/resources/jsx/contests/contest.jsx
+++ b/platform/resources/jsx/contests/contest.jsx
@@ -286,15 +286,23 @@ class Contest extends React.Component {
                             <div key={'test-' + i}>
                                 <h6>Test Case {i+1}</h6>
                                 <pre class="case_text">
-                                    {c.inputs.map((input, i) => {
-                                        return (
-                                            <div key={'input-' + i}>
-                                                <strong>Argument {i+1}</strong>{'\n'}{input}
-                                                {'\n'}
-                                            </div>
-                                        );
-                                    })}
-                                    <strong>Expected Output</strong>{'\n'}{c.output.replace(/\\n/g, '\n')}
+                                    {(c.hide_input && (active || c.hide_ignore_active))
+                                        ? <strong>{c.args.length} hidden argument(s)</strong>
+                                        : c.args.map((input, i) => {
+                                            return (
+                                                <div key={'input-' + i}>
+                                                    <strong>Argument {i+1}</strong>{'\n'}{input}
+                                                    {'\n'}
+                                                </div>
+                                            );
+                                        })
+                                    }
+                                    {'\n'}
+                                    {(c.hide_output && (active || c.hide_ignore_active))
+                                        ? <strong>Hidden Output</strong>
+                                        : <><strong>Expected Output</strong>{'\n'}{c.output.replace(/\\n/g, '\n')}</>
+                                    }
+                                    
                                 </pre>
                             </div>
                         );

--- a/platform/resources/jsx/contests/manage.jsx
+++ b/platform/resources/jsx/contests/manage.jsx
@@ -119,11 +119,13 @@ class Manage extends React.Component {
             return bootbox.alert("The number of test cases do not match the number of expected results");
         }
 
-        let number_of_parameters = test_cases[0].split('|').length;
+        let first_case_inputs = test_cases[0].split('|');
+        let number_of_parameters = first_case_inputs.length - (first_case_inputs[0] == "" ? 2 : 0 ); // if first case is blank, next arg is options
         let valid = true
 
         test_cases.forEach(test_case => {
-            if (test_case.split('|').length !== number_of_parameters) {
+            let case_inputs = test_case.split('|');
+            if ((case_inputs.length - (case_inputs[0] == "" ? 2 : 0)) !== number_of_parameters) {
                 valid = false
             }
         });


### PR DESCRIPTION
Adds an options system for contest inputs, allowing control on a case-by-case basis to hide/show test cases and their outputs.
This system allows for easy expansion in the future if we want to add other special options to each case.

Options are specified in the inputs portion of the cases by starting the case with a `|`, the character used as a input separator:
```
|...options string...|inputs...
```
Note that options do not need to be included to allow for backwards compatibility with existing contests.

Within this options string, you can currently specify 3 options:
* `hide_input` - Hides all arguments for this test case while the contest is active
* `hide_output` - Hide all output for this test case while the contest is active
* `hide_ignore_active` - Hide input/output (depending on if they are already set) regardless of if the contest is active

These are specified by comma separating:
```
|hide_input,hide_output,hide_ignore_active|hidden
|hide_input,hide_output|hidden only when active
|hide_output|not hidden
|hide_input|hidden only when active
not hidden
```
