### PR TITLE
Add the current timestamp to contest embeds

### DIFF
--- a/platform/api/controllers/ContestsController.js
+++ b/platform/api/controllers/ContestsController.js
@@ -285,6 +285,7 @@ module.exports = {
                                 `[Click here](${constant.base_url}${contest.url}) to give it a try.`,
                             type: 'rich',
                             color: 0x84e47f,
+                            timestamp: new Date().toISOString(),
                             url: `${constant.base_url}${contest.url}`,
                             author: {
                                 name:
@@ -294,7 +295,7 @@ module.exports = {
                             },
                             footer: {
                                 icon_url: constant.cdn_url + req.local.user.avatar_url,
-                                text: `updated by ${req.local.user.display_name} right now`
+                                text: `updated by ${req.local.user.display_name}`
                             }
                         }
                     })
@@ -326,6 +327,7 @@ module.exports = {
                                 `[Click here](${constant.base_url}${contest.url}) to give it a try.`,
                             type: 'rich',
                             color: 0x84e47f,
+                            timestamp: new Date().toISOString(),
                             url: `${constant.base_url}${contest.url}`,
                             author: {
                                 name:
@@ -334,7 +336,7 @@ module.exports = {
                             },
                             footer: {
                                 icon_url: constant.cdn_url + req.local.user.avatar_url,
-                                text: `submitted by ${req.local.user.display_name} right now`
+                                text: `submitted by ${req.local.user.display_name}`
                             }
                         }
                     })


### PR DESCRIPTION
This PR updates the embeds sent by felix for contest submissions.

It removes the "right now" at the end and adds the current timestamp in its place.
